### PR TITLE
Feature agregar especialidad vet

### DIFF
--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -264,19 +264,25 @@ class PetsTest(TestCase):
             },
         )
         self.assertContains(response, "Por favor ingrese una fecha de nacimiento valida y anterior a la de hoy")
+
+
 class VetsTest(TestCase):
     def test_repo_use_repo_template(self):
         response = self.client.get(reverse("vets_repo"))
         self.assertTemplateUsed(response, "vets/repository.html")
+    
     def test_repo_display_all_vets(self):
         response = self.client.get(reverse("vets_repo"))
         self.assertTemplateUsed(response, "vets/repository.html")
+    
     def test_form_use_form_template(self):
         response = self.client.get(reverse("vets_form"))
         self.assertTemplateUsed(response, "vets/form.html")
+    
     def test_can_create_vet(self):
         speciality = "Urgencias"
         self.assertTrue(self.is_valid_speciality(speciality))
+        
         response = self.client.post(
             reverse("vets_form"),
             data={
@@ -286,13 +292,17 @@ class VetsTest(TestCase):
                 "speciality": speciality,
             },
         )
+        
         vets = Vet.objects.all()
         self.assertEqual(len(vets), 1)
+        
         self.assertEqual(vets[0].name, "Juan Sebastian Veron")
         self.assertEqual(vets[0].email, "brujita75@hotmail.com")
         self.assertEqual(vets[0].phone, "221555232")
         self.assertEqual(vets[0].speciality, "Urgencias")
+        
         self.assertRedirects(response, reverse("vets_repo"))
+    
     def is_valid_speciality(self, speciality):
         return speciality in [choice.value for choice in Speciality]
     
@@ -301,13 +311,16 @@ class VetsTest(TestCase):
             reverse("vets_form"),
             data={},
         )
+        
         self.assertContains(response, "Por favor ingrese un nombre")
         self.assertContains(response, "Por favor ingrese un email")
         self.assertContains(response, "Por favor ingrese un teléfono")
         self.assertContains(response, "Por favor seleccione una especialidad")
+    
     def test_should_response_with_404_status_if_vet_doesnt_exists(self):
         response = self.client.get(reverse("vets_edit", kwargs={"id": 100}))
         self.assertEqual(response.status_code, 404)
+    
     def test_validation_invalid_email(self):
         response = self.client.post(
             reverse("vets_form"),
@@ -318,7 +331,9 @@ class VetsTest(TestCase):
                 "speciality": "Urgencias",
             },
         )
+        
         self.assertContains(response, "Por favor ingrese un email valido")
+    
     def test_edit_user_with_valid_data_vet(self):
         vet = Vet.objects.create(
             name="Juan Sebastián Veron",
@@ -326,6 +341,7 @@ class VetsTest(TestCase):
             email="brujita75@hotmail.com",
             speciality="Urgencias",
         )
+       
         response = self.client.post(
             reverse("vets_form"),
             data={
@@ -336,12 +352,48 @@ class VetsTest(TestCase):
                 "speciality":vet.speciality,
             },
         )
+        
         self.assertEqual(response.status_code, 302)
+        
         editedVet = Vet.objects.get(pk=vet.id)
+        
         self.assertEqual(editedVet.name, "Guido Carrillo")
         self.assertEqual(editedVet.email, vet.email)
         self.assertEqual(editedVet.phone, vet.phone)
         self.assertEqual(editedVet.speciality, vet.speciality)
+
+    def test_create_vet_with_valid_speciality(self):
+        response = self.client.post(reverse("vets_form"), {
+            "name": "Juan Sebastian Veron",
+            "email": "brujita75@hotmail.com",
+            "phone": "221555232",
+            "speciality": "Urgencias"
+        })
+
+        self.assertEqual(response.status_code, 302)
+
+        self.assertTrue(Vet.objects.filter(name="Juan Sebastian Veron").exists())
+
+    def test_edit_user_with_empty_speciality_vet(self):
+        vet = Vet.objects.create(
+            name="Juan Sebastian Veron",
+            email= "brujita75@hotmail.com",
+            phone= "221555232",
+            speciality= "Urgencias"
+        )
+        response = self.client.post(
+            reverse("vets_form"),
+            data={
+                "id": vet.id,
+                "name": "Juan Sebastian Veron",
+                "email": "brujita75@hotmail.com",
+                "phone": "221555232",
+                "speciality": ""
+            },
+        )
+
+        self.assertContains(response, "Por favor seleccione una especialidad")
+
 
 class ProvidersTest(TestCase):
     def test_repo_use_repo_template(self):

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from app.models import Client, Pet, validate_pet, Vet, Speciality, Provider, validate_provider, validate_product, Medicine, validate_medicine
+from app.models import Client, Pet, validate_pet, Vet, Speciality, validate_vet, Provider, validate_provider, validate_product, Medicine, validate_medicine
 import datetime
 
 
@@ -175,10 +175,13 @@ class PetModelTest(TestCase):
         }
         result = validate_pet(data)
         self.assertIn("Por favor ingrese una fecha de nacimiento valida y anterior a la de hoy",result.values())
+
+
 class VetModelTest(TestCase):
     def test_can_create_and_get_vet(self):
         speciality = "Urgencias"
         self.assertTrue(self.is_valid_speciality(speciality))
+        
         Vet.save_vet(
             {
                 "name": "Juan Sebastian Veron",
@@ -187,12 +190,15 @@ class VetModelTest(TestCase):
                 "speciality": speciality,
             }
         )
+        
         vets = Vet.objects.all()
         self.assertEqual(len(vets), 1)
+        
         self.assertEqual(vets[0].name, "Juan Sebastian Veron")
         self.assertEqual(vets[0].email, "brujita75@hotmail.com")
         self.assertEqual(vets[0].phone, "221555232")
         self.assertEqual(vets[0].speciality, "Urgencias")
+    
     def test_can_update_vet(self):
         Vet.save_vet(
             {
@@ -202,16 +208,21 @@ class VetModelTest(TestCase):
                 "speciality": "Urgencias",
             }
         )
+        
         vet = Vet.objects.get(pk=1)
         self.assertEqual(vet.phone, "221555232")
+        
         vet.update_vet({
             "name": "Juan Sebastian Veron",
             "email": "brujita75@hotmail.com",
             "phone": "221555233",
             "speciality": "Urgencias",
             })
+        
         vet_updated = Vet.objects.get(pk=1)
+        
         self.assertEqual(vet_updated.phone, "221555233")
+    
     def test_update_vet_with_error(self):
         Vet.save_vet(
             {
@@ -221,14 +232,29 @@ class VetModelTest(TestCase):
                 "speciality": "Urgencias",
             }
         )
+        
         vet = Vet.objects.get(pk=1)
         self.assertEqual(vet.phone, "221555232")
+        
         vet.update_vet({"phone": ""})
         vet_updated = Vet.objects.get(pk=1)
+        
         self.assertEqual(vet_updated.phone, "221555232")
 
     def is_valid_speciality(self, speciality):
         return speciality in [choice.value for choice in Speciality]
+    
+    def test_empty_speciality_error(self):
+        data = {
+            "name": "Juan Sebastian Veron",
+            "email": "brujita75@hotmail.com",
+            "phone": "221555232",
+            "speciality": "",
+        }
+
+        errors = validate_vet(data)
+
+        self.assertIn("Por favor seleccione una especialidad", errors.values())
 
 class ProviderModelTest(TestCase):
     # TESTS para el alta de proveedores


### PR DESCRIPTION
Este PR agrega tres funciones para los tests respecto a agregar el atributo especialidad en la clase Vet:
Una función en test de unidad para verificar que cuando se quiere enviar el formulario con el campo de especialidad vacío devuelva el mensaje de error.
Dos funciones en test de integración, una para verificar que una instancia se cree correctamente cuando se le ingresa un valor de especialidad correcto, y la otra función para corroborar que al enviar el formulario con el campo de especialidad vacío devuelva el mensaje de error correspondiente.