### PR TITLE
Correccion: muestra de precio de producto al editar

### DIFF
--- a/app/templates/products/form.html
+++ b/app/templates/products/form.html
@@ -52,12 +52,22 @@
                 </div>
                 <div>
                     <label for="price" class="form-label">Precio</label>
-                    <input type="number"
-                        id="price"
-                        name="price"
-                        class="form-control"
-                        value=""
-                        required/>
+                    
+                    {% if product.price and not errors.price %}
+                        <input type="number"
+                            id="price"
+                            name="price"
+                            class="form-control"
+                            value="{{product.price}}"
+                            required/>
+                    {% else %}
+                        <input type="number"
+                            id="price"
+                            name="price"
+                            class="form-control"
+                            value=""
+                            required/>
+                    {% endif %}
 
                     {% if errors.price %}
                         <div class="invalid-feedback">


### PR DESCRIPTION
Este PR arregla que cuando se quiere editar el precio de un producto, se siga mostrando y no desaparezca como pasaba antes cuando se hacía click al editar en un producto que habiamos creado. 