### PR TITLE
Aplica configuraciones necesarias para el deploy en Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
 #Importamos una imagen de python para no tener que construir todo en base al SO
 FROM python:3.12-slim
 
-#ENV DB_ENGINE=
-#ENV DB_NAME=
-#ENV DEBUG=
-#ENV SECRET_KEY=
-#ENV ALLOWED_HOSTS=
-#ENV LANGUAGE_CODE=
-#ENV TIME_ZONE=
-
 #Elijo el directorio raíz de la aplicación como directorio de trabajo 
 WORKDIR .
 

--- a/vetsoft/settings.py
+++ b/vetsoft/settings.py
@@ -31,8 +31,11 @@ SECRET_KEY = os.getenv("SECRET_KEY", default_secret_key)#"django-insecure-p)^5i@
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv("DEBUG")
 
-ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '*').split(',')#['0.0.0.0', 'localhost','127.0.0.1']
+ALLOWED_HOSTS = ['0.0.0.0', 'localhost', '127.0.0.1', '*', 'https://vetsoft-1-0.onrender.com']
 
+CSRF_TRUSTED_ORIGINS = [
+    'https://vetsoft-1-0.onrender.com',
+]
 
 
 # Application definition


### PR DESCRIPTION
Para poder hacer el deploy en render, había que configurar entre los puertos permitidos, el dominio del deploy. Además, había que configurar este último como seguro para el CSRF.