### PR TITLE
Fix: Se arregla la validacion del email de cliente

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -37,7 +37,9 @@ def validate_client(data):
 
     if email == "":
         errors["email"] = "Por favor ingrese un email"
-    elif email.count("@") == 0:
+    elif email.count(" ") > 0:
+        errors["email"] = "Por favor ingrese un email sin espacios en blanco"
+    elif email.count("@") == 0 or email.count("@") > 1:
         errors["email"] = "Por favor ingrese un email valido"
     elif not email.endswith('@vetsoft.com'):
         errors["email"] = "Por favor ingrese un email que incluya '@vetsoft.com'"

--- a/app/models.py
+++ b/app/models.py
@@ -41,6 +41,8 @@ def validate_client(data):
         errors["email"] = "Por favor ingrese un email valido"
     elif not email.endswith('@vetsoft.com'):
         errors["email"] = "Por favor ingrese un email que incluya '@vetsoft.com'"
+    elif email == "@vetsoft.com":
+        errors["email"] = "Por favor ingrese un email válido, no solo '@vetsoft.com'"
 
     if city == "":
         errors["city"] = "Por favor seleccione una ciudad"

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -130,6 +130,54 @@ class ClientsTest(TestCase):
 
             self.assertContains(response, "Por favor ingrese un email que incluya &#x27;@vetsoft.com&#x27")
 
+    def test_validation_invalid_email_only_vetsoft_com(self):
+            """
+            Prueba si se muestra un error de validación cuando se ingresa un email con solo 'vetsoft.com'
+            """
+            response = self.client.post(
+                reverse("clients_form"),
+                data={
+                    "name": "Juan Sebastian Veron",
+                    "phone": "221555232",
+                    "address": "13 y 44",
+                    "email": "@vetsoft.com",
+                },
+            )
+
+            self.assertContains(response, "Por favor ingrese un email válido, no solo &#x27;@vetsoft.com&#x27")
+
+    def test_validation_invalid_email_with_more_than_one_at_sign(self):
+            """
+            Prueba si se muestra un error de validación cuando se ingresa un email que mas de un @
+            """
+            response = self.client.post(
+                reverse("clients_form"),
+                data={
+                    "name": "Juan Sebastian Veron",
+                    "phone": "221555232",
+                    "address": "13 y 44",
+                    "email": "brujita@75@gmail.com",
+                },
+            )
+
+            self.assertContains(response, "Por favor ingrese un email valido")
+
+    def test_validation_invalid_email_with_white_space(self):
+            """
+            Prueba si se muestra un error de validación cuando se ingresa un email con espacios en blanco
+            """
+            response = self.client.post(
+                reverse("clients_form"),
+                data={
+                    "name": "Juan Sebastian Veron",
+                    "phone": "221555232",
+                    "address": "13 y 44",
+                    "email": "brujita 75@gmail.com",
+                },
+            )
+
+            self.assertContains(response, "Por favor ingrese un email sin espacios en blanco")
+
     def test_edit_user_with_valid_data(self):
         """
         Prueba si se puede editar un cliente con datos válidos.
@@ -208,6 +256,78 @@ class ClientsTest(TestCase):
         )
 
         self.assertContains(response, "Por favor ingrese un email que incluya &#x27;@vetsoft.com&#x27")
+    
+    def test_edit_user_with_invalid_email_only_vetsoft_com(self):
+        """
+        Prueba si se muestra un error de validación cuando se edita un email con solo 'vetsoft.com'
+        """ 
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "id": client.id,
+                "name": client.name, 
+                "city":client.city,
+                "phone":client.phone,
+                "email":"@vetsoft.com",
+            },
+        )
+
+        self.assertContains(response, "Por favor ingrese un email válido, no solo &#x27;@vetsoft.com&#x27")
+
+    def test_edit_user_with_invalid_email_more_than_one_at_sign(self):
+        """
+        Prueba si se muestra un error de validación cuando se edita un email con mas de un @
+        """ 
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "id": client.id,
+                "name": client.name, 
+                "city":client.city,
+                "phone":client.phone,
+                "email":"brujita@75@vetsoft.com",
+            },
+        )
+
+        self.assertContains(response, "Por favor ingrese un email valido")
+
+    def test_edit_user_with_invalid_email_with_white_spaces(self):
+        """
+        Prueba si se muestra un error de validación cuando se edita un email con espacios en blanco
+        """ 
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "id": client.id,
+                "name": client.name, 
+                "city":client.city,
+                "phone":client.phone,
+                "email":"brujita 75@gmail.com",
+            },
+        )
+
+        self.assertContains(response, "Por favor ingrese un email sin espacios en blanco")
     
     def test_validation_invalid_name_client(self):
         """

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -71,6 +71,42 @@ class ClientModelTest(TestCase):
         self.assertIn("email", errors)
         self.assertEqual(errors["email"], "Por favor ingrese un email que incluya '@vetsoft.com'")
 
+    def test_create_client_with_invalid_email_only_vetsoft_com(self):
+        """Intenta crear un cliente con solamente '@vetsoft.com' en el mail"""
+        data = {
+                "name": "Juan Sebastian Veron",
+                "phone": "221555232",
+                "city": "La Plata",
+                "email": "@vetsoft.com",
+            }
+        errors = validate_client(data)
+        self.assertIn("email", errors)
+        self.assertEqual(errors["email"], "Por favor ingrese un email válido, no solo '@vetsoft.com'")
+
+    def test_create_client_with_invalid_email_more_than_one_at_sign(self):
+        """Intenta crear un cliente con mas de un @ en el mail"""
+        data = {
+                "name": "Juan Sebastian Veron",
+                "phone": "221555232",
+                "city": "La Plata",
+                "email": "brujita@veron@vetsoft.com",
+            }
+        errors = validate_client(data)
+        self.assertIn("email", errors)
+        self.assertEqual(errors["email"], "Por favor ingrese un email valido")
+
+    def test_create_client_with_invalid_email_white_space(self):
+        """Intenta crear un cliente con espacios en blanco en el mail"""
+        data = {
+                "name": "Juan Sebastian Veron",
+                "phone": "221555232",
+                "city": "La Plata",
+                "email": "ro tantos@vetsoft.com",
+            }
+        errors = validate_client(data)
+        self.assertIn("email", errors)
+        self.assertEqual(errors["email"], "Por favor ingrese un email sin espacios en blanco")
+
     def test_can_update_client(self):
         """Prueba que se pueda actualizar la información de un cliente correctamente."""
         Client.save_client(
@@ -163,7 +199,67 @@ class ClientModelTest(TestCase):
         client_updated = Client.objects.get(pk=1)
         
         self.assertEqual(client_updated.email, "brujita75@vetsoft.com")
+
+    def test_edit_client_with_invalid_email_only_vetsoft_com(self):
+        """Intenta editar un cliente con solamente '@vetsoft.com' en el mail"""
+        Client.save_client(
+            {
+                "name": "Juan Sebastian Veron",
+                "phone": "54221555232",
+                "city": "La Plata",
+                "email": "brujita75@vetsoft.com",
+            },
+        )
+        client = Client.objects.get(pk=1)
+
+        self.assertEqual(client.email, "brujita75@vetsoft.com")
+
+        client.update_client({"email": "@vetsoft.com"})
+
+        client_updated = Client.objects.get(pk=1)
         
+        self.assertEqual(client_updated.email, "brujita75@vetsoft.com")
+
+    def test_edit_client_with_invalid_email_more_than_one_at_sign(self):
+        """Intenta editar un cliente con mas de un @ en el mail"""
+        Client.save_client(
+            {
+                "name": "Juan Sebastian Veron",
+                "phone": "54221555232",
+                "city": "La Plata",
+                "email": "brujita75@vetsoft.com",
+            },
+        )
+        client = Client.objects.get(pk=1)
+
+        self.assertEqual(client.email, "brujita75@vetsoft.com")
+
+        client.update_client({"email": "brujita@75@vetsoft.com"})
+
+        client_updated = Client.objects.get(pk=1)
+        
+        self.assertEqual(client_updated.email, "brujita75@vetsoft.com")
+
+    def test_edit_client_with_invalid_email_white_space(self):
+        """Intenta editar un cliente con espacios en blanco en el mail"""
+        Client.save_client(
+            {
+                "name": "Juan Sebastian Veron",
+                "phone": "54221555232",
+                "city": "La Plata",
+                "email": "brujita75@vetsoft.com",
+            },
+        )
+        client = Client.objects.get(pk=1)
+
+        self.assertEqual(client.email, "brujita75@vetsoft.com")
+
+        client.update_client({"email": "brujita 75@vetsoft.com"})
+
+        client_updated = Client.objects.get(pk=1)
+        
+        self.assertEqual(client_updated.email, "brujita75@vetsoft.com")
+
     def test_update_client_with_empty_name(self):
         """Prueba que verifica si se produce un error al intentar actualizar un cliente con un campo de nombre vacío.""" 
         Client.save_client(

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -276,6 +276,57 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
             self.page.get_by_text("Por favor ingrese un email que incluya '@vetsoft.com'"),
         ).to_be_visible()
 
+    def test_should_view_errors_if_email_is_invalid_only_vetsoft_com(self):
+        """Verifica si se muestran errores si el email contiene solamente 'vetsoft.com'."""
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("@vetsoft.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email válido, no solo '@vetsoft.com'"),
+        ).to_be_visible()
+
+    def test_should_view_errors_if_email_is_invalid_more_than_one_at_sign(self):
+        """Verifica si se muestran errores si el email contiene mas de un @"""
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("brujita@75@gmail.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email valido"),
+        ).to_be_visible()
+
+    def test_should_view_errors_if_email_is_invalid_vetsoft_com_white_spaces(self):
+        """Verifica si se muestran errores si el email contiene espacios en blanco"""
+        self.page.goto(f"{self.live_server_url}{reverse('clients_form')}")
+
+        expect(self.page.get_by_role("form")).to_be_visible()
+
+        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
+        self.page.get_by_label("Teléfono").fill("54221555232")
+        self.page.get_by_label("Email").fill("brujita 75@gmail.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email sin espacios en blanco"),
+        ).to_be_visible()
+
     def test_should_be_able_to_edit_a_client(self):
         """Verifica si se puede editar un cliente."""
         client = Client.objects.create(
@@ -331,6 +382,75 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
 
         expect(
             self.page.get_by_text("Por favor ingrese un email valido"),
+        ).to_be_visible()
+
+    def test_should_not_be_able_to_edit_a_client_if_invalid_email_only_vetsoft_com(self):
+        """Verifica si se aparece un mensaje de error para email en caso de ingresar solamente @vetsoft.com"""
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        path = reverse("clients_edit", kwargs={"id": client.id})
+        self.page.goto(f"{self.live_server_url}{path}")
+
+        self.page.get_by_label("Nombre").fill("Guido Carrillo")
+        self.page.get_by_label("Teléfono").fill("54221232555")
+        self.page.get_by_label("Email").fill("@vetsoft.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email válido, no solo '@vetsoft.com'"),
+        ).to_be_visible()
+
+    def test_should_not_be_able_to_edit_a_client_if_invalid_email_more_than_one_at_sign(self):
+        """Verifica si se aparece un mensaje de error para email en caso de ingresar mas de un @"""
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        path = reverse("clients_edit", kwargs={"id": client.id})
+        self.page.goto(f"{self.live_server_url}{path}")
+
+        self.page.get_by_label("Nombre").fill("Guido Carrillo")
+        self.page.get_by_label("Teléfono").fill("54221232555")
+        self.page.get_by_label("Email").fill("brujita@75@vetsoft.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email valido"),
+        ).to_be_visible()
+
+    def test_should_not_be_able_to_edit_a_client_if_invalid_email_with_white_spaces(self):
+        """Verifica si se aparece un mensaje de error para email en caso de ingresar espacios en blanco"""
+        client = Client.objects.create(
+            name="Juan Sebastián Veron",
+            city="La Plata",
+            phone="54221555232",
+            email="brujita75@vetsoft.com",
+        )
+
+        path = reverse("clients_edit", kwargs={"id": client.id})
+        self.page.goto(f"{self.live_server_url}{path}")
+
+        self.page.get_by_label("Nombre").fill("Guido Carrillo")
+        self.page.get_by_label("Teléfono").fill("54221232555")
+        self.page.get_by_label("Email").fill("brujita 75@vetsoft.com")
+        self.page.select_option("select[name=city]", value="La Plata")
+
+        self.page.get_by_role("button", name="Guardar").click()
+
+        expect(
+            self.page.get_by_text("Por favor ingrese un email sin espacios en blanco"),
         ).to_be_visible()
 
     def test_should_not_be_able_to_edit_a_client_if_invalid_email_vetsoft_com(self):


### PR DESCRIPTION
La validación del email del cliente, la cual tuvo previamente un bug y que fue supuestamente solucionada, daba como correcto el ingreso de solamente "@vetsoft.com", es decir, sin caracteres previo al dominio.